### PR TITLE
WA-541 Disable open the popup when dApp is not whitelisted

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -62,7 +62,9 @@ chrome.runtime.onMessage.addListener(
         break
 
       case MSG_SHOW_POPUP:
-        showSendTransactionPopup(request.tx, sender.tab.windowId, sender.tab.id)
+        if (isWhiteListedDapp(normalizeUrl(sender.tab.url))) {
+          showSendTransactionPopup(request.tx, sender.tab.windowId, sender.tab.id)
+        }
         break
 
       case MSG_LOCK_ACCOUNT_TIMER:


### PR DESCRIPTION
The URL of the sender of the event `EV_SHOW_POPUP` is now checked to see if it is whitelisted or not.