### PR TITLE
Use operationalGas to calculate transaction fee

### DIFF
--- a/app/routes/popup/Transaction/components/components/TransactionSummary/index.js
+++ b/app/routes/popup/Transaction/components/components/TransactionSummary/index.js
@@ -9,18 +9,12 @@ import styles from 'assets/css/global.css'
 class TransactionSummary extends Component {
   constructor (props) {
     super(props)
-    const {
-      transaction,
-      estimations,
-      displayedValue
-    } = this.props
+    const { transaction } = this.props
     this.state = {
       ethBalance: undefined
     }
 
     this.isTokenTransfer = isTokenTransfer(transaction.data)
-    this.transactionFee = this.calculateTransactionFee(estimations)
-    this.totalCost = this.calculateTotalCost(displayedValue)
   }
 
   componentDidMount = async () => {
@@ -51,6 +45,13 @@ class TransactionSummary extends Component {
 
   render () {
     const { ethBalance } = this.state
+    const {
+      estimations,
+      displayedValue
+    } = this.props
+
+    this.transactionFee = this.calculateTransactionFee(estimations)
+    this.totalCost = this.calculateTotalCost(displayedValue)
 
     const txFeeString = this.transactionFee ? -this.transactionFee.toString(10) : '-'
     const txCostString = this.totalCost ? -this.totalCost.toString(10) : '-'

--- a/app/routes/popup/Transaction/containers/transactions.js
+++ b/app/routes/popup/Transaction/containers/transactions.js
@@ -52,10 +52,11 @@ export const setUpTransaction = (tx, estimations, displayedValue, decimals) => {
     return
   }
 
-  tx.txGas = new BigNumber(estimations.safeTxGas).toString(10)
   tx.dataGas = new BigNumber(estimations.dataGas).toString(10)
   tx.gasPrice = new BigNumber(estimations.gasPrice).toString(10)
   tx.gasToken = estimations.gasToken
+  tx.operationalGas = new BigNumber(estimations.operationalGas).toString(10)
+  tx.txGas = new BigNumber(estimations.safeTxGas).toString(10)
 }
 
 export const calculateGasEstimation = async (
@@ -68,10 +69,11 @@ export const calculateGasEstimation = async (
     estimations = await getTransactionEstimations(tx.from, tx.to, estimationValue, tx.data, 0)
   } else {
     estimations = {
-      safeTxGas: tx.txGas,
       dataGas: tx.dataGas,
       gasPrice: tx.gasPrice,
-      gasToken: tx.gasToken
+      gasToken: tx.gasToken,
+      operationalGas: tx.operationalGas,
+      safeTxGas: tx.txGas
     }
   }
   return estimations

--- a/app/utils/sendNotifications.js
+++ b/app/utils/sendNotifications.js
@@ -33,6 +33,7 @@ export const sendTransaction = async (
     operation: tx.operation,
     txGas: tx.txGas,
     dataGas: tx.dataGas,
+    operationalGas: tx.operationalGas,
     gasPrice: tx.gasPrice,
     gasToken: tx.gasToken,
     nonce: tx.nonce,


### PR DESCRIPTION
Use `operationalGas` parameter returned from the relay service (`/estimate` endpoint) to calculate the transaction fee.