### PR TITLE
Update links pointing to mobile apps

### DIFF
--- a/app/routes/extension/DownloadApps/components/Layout.js
+++ b/app/routes/extension/DownloadApps/components/Layout.js
@@ -53,7 +53,7 @@ class Layout extends Component {
             <ol>
               <li>
                 <p>{DOWNLOAD_MOBILE_APP}</p>
-                <button onClick={toggleQrIos} data-os='ios'>{IPHONE_AND_IPAD}</button>
+                {/* <button onClick={toggleQrIos} data-os='ios'>{IPHONE_AND_IPAD}</button> */}
                 <button onClick={toggleQrAndroid} data-os='android'>{ANDROID}</button>
               </li>
               <li>

--- a/config/env.config.js
+++ b/config/env.config.js
@@ -32,7 +32,7 @@ const stagingTransactionRelayServiceUrl = 'https://safe-relay.staging.gnosisdev.
 
 const envConfig = {
   [PRODUCTION]: {
-    [ANDROID_APP_URL]: 'https://play.google.com/apps/testing/pm.gnosis.heimdall.dev',
+    [ANDROID_APP_URL]: 'https://play.google.com/store/apps/details?id=pm.gnosis.heimdall',
     [IOS_APP_URL]: 'https://testflight.apple.com/join/fMCYpOfT',
     [PUSH_NOTIFICATION_SERVICE_URL]: process.env.PUSH_NOTIFICATION_SERVICE_URL,
     [TRANSACTION_RELAY_SERVICE_URL]: {


### PR DESCRIPTION
The button to download the iOS app will be hidden for the Mainnet release.

The link pointing to the android app has been updated to use the Mainnet version.