### PR TITLE
Fix multiple confirmations

### DIFF
--- a/app/routes/popup/Transaction/containers/Transaction.js
+++ b/app/routes/popup/Transaction/containers/Transaction.js
@@ -118,8 +118,10 @@ class Transaction extends Component {
   }
 
   removeTransaction = async (position) => {
-    const { transactions } = this.props
-    var removeTx = this.props.onRemoveTransaction
+    const {
+      transactions,
+      onRemoveTransaction
+    } = this.props
 
     const transactionsLength = transactions.txs.length - 1
     chrome.browserAction.setBadgeBackgroundColor({ color: '#888' })
@@ -127,13 +129,17 @@ class Transaction extends Component {
 
     const transaction = transactions.txs[position]
 
-    await chrome.tabs.query({ windowId: transaction.dappWindowId }, (tabs) => {
-      chrome.tabs.sendMessage(transaction.dappTabId, {
-        msg: messages.MSG_RESOLVED_TRANSACTION,
-        hash: null,
-        id: transaction.tx.id
-      }, () => removeTx(position))
-    })
+    if (transaction.dappWindowId && transaction.dappTabId) {
+      await chrome.tabs.query({ windowId: transaction.dappWindowId }, (tabs) => {
+        chrome.tabs.sendMessage(transaction.dappTabId, {
+          msg: messages.MSG_RESOLVED_TRANSACTION,
+          hash: null,
+          id: transaction.tx.id
+        }, () => onRemoveTransaction(position))
+      })
+    } else {
+      onRemoveTransaction(position)
+    }
   }
 
   getSafeAlias = (address) => {

--- a/config/manifest_template.json
+++ b/config/manifest_template.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": null,
   "short_name": "Gnosis Safe",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "browser_action": {
     "default_title": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-browser-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-browser-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "app/index.js",
   "scripts": {
     "build:dev": "cross-env NODE_ENV=development webpack --progress",


### PR DESCRIPTION
Fixes the issue: https://github.com/gnosis/safe-browser-extension/issues/89

When transactions are triggered from the mobile app, they are removed from the pop-up window after confirmation/rejection.