### PR TITLE
Fix bug in the qr-code for replacing the recovery key

### DIFF
--- a/app/routes/extension/ReplaceRecoveryPhrase/containers/ReplaceRecoveryPhrase.js
+++ b/app/routes/extension/ReplaceRecoveryPhrase/containers/ReplaceRecoveryPhrase.js
@@ -48,13 +48,13 @@ class ReplaceRecoveryPhrase extends Component {
   generateQrCodeContent = (safeAddress) => {
     const {
       selectEncryptedMnemonic,
-      selectUnencryptedMnemonicSelector
+      selectUnencryptedMnemonic
     } = this.props
 
-    const account = !selectUnencryptedMnemonicSelector && this.password
+    const account = !selectUnencryptedMnemonic && this.password
       ? getDecryptedEthAccount(selectEncryptedMnemonic, this.password)
-      : createAccountFromMnemonic(selectUnencryptedMnemonicSelector)
-
+      : createAccountFromMnemonic(selectUnencryptedMnemonic)
+    
     const data = EthUtil.sha3('GNO' + safeAddress)
     const vrs = EthUtil.ecsign(data, account.getPrivateKey())
     const r = new BigNumber(EthUtil.bufferToHex(vrs.r))

--- a/app/routes/extension/ResyncToken/containers/ResyncToken.js
+++ b/app/routes/extension/ResyncToken/containers/ResyncToken.js
@@ -34,14 +34,14 @@ class ResyncToken extends Component {
   handleResync = () => async (e) => {
     const {
       selectEncryptedMnemonic,
-      selectUnencryptedMnemonicSelector
+      selectUnencryptedMnemonic
     } = this.props
 
-    const currentAccount = !selectUnencryptedMnemonicSelector && this.password
+    const currentAccount = !selectUnencryptedMnemonic && this.password
       ? getDecryptedEthAccount(selectEncryptedMnemonic, this.password)
-      : createAccountFromMnemonic(selectUnencryptedMnemonicSelector)
+      : createAccountFromMnemonic(selectUnencryptedMnemonic)
 
-    try {
+      try {
       const token = await setUpNotifications()
       if (token === null) {
         this.setState({ message: ERROR_SYNCING })


### PR DESCRIPTION
**Before:**
- When the browser extension was unlocked, a valid qr-code for replacing the recovery key was generated.
- When the browser extension was locked, an invalid qr-code for replacing the recovery key was generated.

**Now:**
- When the browser extension is unlocked, a valid qr-code for replacing the recovery key is generated.
- When the browser extension is locked, a valid qr-code for replacing the recovery key is generated.
