### PR TITLE
Hide unknown push notifications

### DIFF
--- a/extension/firebase-messaging-sw.js
+++ b/extension/firebase-messaging-sw.js
@@ -7,6 +7,7 @@ self.addEventListener('push', (event) => {
   const payload = event.data.json().data
 
   let title, message, url
+  let knownPush = true
   switch (payload.type) {
     case 'safeCreation':
       title = 'Safe connected'
@@ -36,36 +37,41 @@ self.addEventListener('push', (event) => {
       break
 
     default:
-      return
+      knownPush = false
   }
 
-  self.clients.matchAll({ includeUncontrolled: true })
-    .then((clients) => {
-      const client = clients.filter(client =>
-        client.url.split('/')[3] === '_generated_background_page.html'
-      )[0]
-      client.postMessage(payload)
-    })
-    .catch((err) => {
-      console.error(err)
-    })
+  if (knownPush) {
+    self.clients.matchAll({ includeUncontrolled: true })
+      .then((clients) => {
+        const client = clients.filter(client =>
+          client.url.split('/')[3] === '_generated_background_page.html'
+        )[0]
+        client.postMessage(payload)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
 
-  event.waitUntil(
-    self.registration.showNotification(
-      title,
-      {
-        body: message,
-        icon: notificationImage,
-        data: {
-          url
+    event.waitUntil(
+      self.registration.showNotification(
+        title,
+        {
+          body: message,
+          icon: notificationImage,
+          data: {
+            url
+          }
         }
-      }
-    ).then(() =>
-      self.registration.getNotifications()
-    ).then(notifications => {
-      setTimeout(() => notifications.forEach(notification => notification.close()), 6000)
-    })
-  )
+      ).then(() =>
+        self.registration.getNotifications()
+      ).then(notifications => {
+        setTimeout(() => notifications.forEach(notification => notification.close()), 6000)
+      })
+    )
+  }
+  else {
+    event.waitUntil(new Promise(() => {}))
+  }
 })
 
 self.addEventListener('notificationclick', (event) => {


### PR DESCRIPTION
When the service worker receives an unknown push notification that is not defined in the code, Chrome browser displays a notification with the default message: `This site has been updated in the background`

This PR hides any notification received that is not defined in the code.