### PR TITLE
Allow to reject a transaction triggered from a Dapp with the extension locked

### DIFF
--- a/app/components/Footers/FooterButtons/containers/index.js
+++ b/app/components/Footers/FooterButtons/containers/index.js
@@ -21,10 +21,11 @@ class FooterButtons extends Component {
   handleRejection = () => {
     const {
       handleRejection,
-      account
+      account,
+      rejectWithExtensionLockedAllowed
     } = this.props
 
-    if (account.lockedState) {
+    if (account.lockedState && !rejectWithExtensionLockedAllowed) {
       this.setState({ requestResolved: true })
     } else {
       handleRejection()

--- a/app/routes/popup/Transaction/components/SendTransaction/components/Layout.js
+++ b/app/routes/popup/Transaction/components/SendTransaction/components/Layout.js
@@ -41,6 +41,7 @@ class Layout extends Component {
                 confirmationText={CONFIRM}
                 handleRejection={handleRejectTransaction}
                 handleConfirmation={handleConfirmTransaction}
+                rejectWithExtensionLockedAllowed
               />
             )}
           </React.Fragment>

--- a/config/manifest_template.json
+++ b/config/manifest_template.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": null,
   "short_name": "Gnosis Safe",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "browser_action": {
     "default_title": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-browser-extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-browser-extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "app/index.js",
   "scripts": {
     "build:dev": "cross-env NODE_ENV=development webpack --progress",


### PR DESCRIPTION
This allows to reject a transaction triggered from a Dapp with the extension locked. There is no point in requesting the password in this case, this is needed only if the transaction is triggered from the mobile app and the extension sends a rejection message signed.


